### PR TITLE
Ensure links can still be clicked on focused messages

### DIFF
--- a/lib/Event/EventWrapper.jsx
+++ b/lib/Event/EventWrapper.jsx
@@ -37,6 +37,7 @@ const EventWrapper = styled(Flex) `
 		z-index: 1;
 		animation: pulse 0.7s 6;
 		animation-direction: alternate;
+		pointer-events: none;
 	}
 	position: relative;
 


### PR DESCRIPTION
Need to disable pointer-events on the :after element as it covers (transparently) the rest of the event element.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

Closes https://github.com/product-os/jellyfish/issues/4571