### PR TITLE
perf: reduce re-renders triggered by message typing

### DIFF
--- a/lib/FileUploader.jsx
+++ b/lib/FileUploader.jsx
@@ -37,7 +37,7 @@ export const FileUploader = ({
 		const files = Array.from(event.target.files)
 		event.target.value = ''
 		onChange(files)
-	}, [])
+	}, [ onChange ])
 
 	return (
 		<React.Fragment>
@@ -83,7 +83,7 @@ export const FilesInput = ({
 		onChange(value.filter((item) => {
 			return item !== file
 		}))
-	}, [ value ])
+	}, [ onChange, value ])
 
 	return (
 		<Flex {...rest} alignItems="center">

--- a/lib/Timeline/tests/index.spec.jsx
+++ b/lib/Timeline/tests/index.spec.jsx
@@ -228,12 +228,7 @@ ava('A message is not removed from the pendingMessage list until it has been add
 		.childAt(0)
 		.instance()
 
-	await timeline.addMessage({
-		preventDefault: _.noop,
-		target: {
-			value: 'Here is a new message'
-		}
-	})
+	await timeline.addMessage('Here is a new message', false)
 
 	const pendingMessages = timeline.state.pendingMessages
 	test.is(pendingMessages.length, 1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9066,6 +9066,41 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "react-app-polyfill": {
@@ -9131,6 +9166,50 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-fast-compare": {
@@ -10096,6 +10175,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "json-e": "^4.1.0",
     "lodash": "^4.17.19",
     "mark.js": "^8.11.1",
+    "memoize-one": "^5.1.1",
     "mixpanel-browser": "^2.38.0",
     "moment": "^2.27.0",
     "node-emoji": "^1.10.0",


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

Refactor MessageInput and Timeline components to reduce the amount of component re-renders caused by typing text.

We now maintain the message state within the `MessageInput` component and only call up to the `Timeline` component when submitting a message. This prevents the whole timeline being re-rendered Every Time You Type A Character

And we now only persist the message (to redux state) when unmounting the component - rather than Every Time You Type A Character... (preventing a whole second round of re-renders on every character typed!)


### Rendering timeline components as you type

#### Before
(Notice that the **_whole_** timeline is re-rendered **_twice_** every time you type a character!)

![Timeline Component renders - before perf improvements](https://user-images.githubusercontent.com/2925657/89769312-1e7df480-db27-11ea-8123-57c25ff37dd3.gif)

#### After
Only the MessageInput component is re-rendered when you type characters

![Timeline Component renders - after perf improvements](https://user-images.githubusercontent.com/2925657/89769321-22117b80-db27-11ea-9a06-e3d48290685c.gif)

### Profiling typing 'Test' in the message textarea

#### Before
![Performance - writing Test before perf improvements - Summary](https://user-images.githubusercontent.com/2925657/89769403-48cfb200-db27-11ea-99a0-d2c15facab9c.jpg)
![Performance - writing Test before perf improvements](https://user-images.githubusercontent.com/2925657/89769406-4bcaa280-db27-11ea-818e-212b95a75e87.jpg)

#### After
![Performance - writing Test after perf improvements - Summary](https://user-images.githubusercontent.com/2925657/89769418-4ff6c000-db27-11ea-8f36-fe8fdca910b7.jpg)
![Performance - writing Test after perf improvements](https://user-images.githubusercontent.com/2925657/89769425-52591a00-db27-11ea-8e6b-c48c4df3b64a.jpg)
