### PR TITLE
patch: Fix interface to MessageInput

### DIFF
--- a/lib/Timeline/index.jsx
+++ b/lib/Timeline/index.jsx
@@ -102,9 +102,9 @@ class Timeline extends React.Component {
 			this.props.signalTyping(this.props.card.id)
 		}, 1500)
 
-		this.preserveMessage = _.debounce((newMessage) => {
+		this.preserveMessage = (newMessage) => {
 			this.props.setTimelineMessage(this.props.card.id, newMessage)
-		}, 1500)
+		}
 	}
 
 	async componentDidMount () {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "json-e": "^4.1.0",
     "lodash": "^4.17.19",
     "mark.js": "^8.11.1",
-    "memoize-one": "^5.1.1",
     "mixpanel-browser": "^2.38.0",
     "moment": "^2.27.0",
     "node-emoji": "^1.10.0",


### PR DESCRIPTION
Also removed unused memoize-one dependency (note - it's still used by react itself).

No need to debounce preserveMessage as it is only called on unmount.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>