### PR TITLE
Use rendition notifications

### DIFF
--- a/lib/Event/Attachments/index.jsx
+++ b/lib/Event/Attachments/index.jsx
@@ -9,6 +9,9 @@ import React from 'react'
 import {
 	saveAs
 } from 'file-saver'
+import {
+	addNotification
+} from '../../services/notifications'
 import AttachmentButton from './AttachmentButton'
 import MessageContainer from '../MessageContainer'
 import AuthenticatedImage from '../../AuthenticatedImage'
@@ -55,8 +58,7 @@ export default class Attachments extends React.Component {
 	downloadAttachments (event) {
 		const {
 			card,
-			sdk,
-			addNotification
+			sdk
 		} = this.props
 		const attachments = getAttachments(card)
 		const attachmentSlug = event.currentTarget.dataset.attachmentslug
@@ -76,7 +78,6 @@ export default class Attachments extends React.Component {
 			card,
 			actor,
 			sdk,
-			addNotification,
 			maxImageSize,
 			squashTop,
 			squashBottom
@@ -112,7 +113,6 @@ export default class Attachments extends React.Component {
 							data-test="event-card__image"
 							cardId={card.id}
 							fileName={attachment.slug}
-							addNotification={addNotification}
 							sdk={sdk}
 							mimeType={attachment.mime}
 							maxImageSize={maxImageSize}

--- a/lib/Event/Event.jsx
+++ b/lib/Event/Event.jsx
@@ -329,7 +329,6 @@ export default class Event extends React.Component {
 							actor={actor}
 							isMessage={isMessage}
 							messageOverflows={messageOverflows}
-							addNotification={actions.addNotification}
 							setMessageElement={this.setMessageElement}
 							messageCollapsedHeight={MESSAGE_COLLAPSED_HEIGHT}
 							enableAutocomplete={enableAutocomplete}

--- a/lib/Event/EventBody.jsx
+++ b/lib/Event/EventBody.jsx
@@ -135,7 +135,6 @@ const EventBody = (props) => {
 		updating,
 		onUpdateDraft,
 		onSaveEditedMessage,
-		addNotification,
 		messageOverflows,
 		setMessageElement,
 		messageCollapsedHeight
@@ -172,7 +171,6 @@ const EventBody = (props) => {
 				card={card}
 				actor={actor}
 				sdk={sdk}
-				addNotification={addNotification}
 				maxImageSize={MAX_IMAGE_SIZE}
 				squashTop={squashTop}
 				squashBottom={squashBottom}

--- a/lib/Event/tests/Attachments.spec.jsx
+++ b/lib/Event/tests/Attachments.spec.jsx
@@ -35,12 +35,7 @@ const {
 
 const sandbox = sinon.createSandbox()
 
-const actions = {
-	addNotification: sandbox.fake()
-}
-
 const commonProps = {
-	actions,
 	user,
 	actor
 }

--- a/lib/Event/tests/Event.spec.jsx
+++ b/lib/Event/tests/Event.spec.jsx
@@ -64,12 +64,7 @@ const {
 
 const sandbox = sinon.createSandbox()
 
-const actions = {
-	addNotification: sandbox.fake()
-}
-
 const commonProps = {
-	actions,
 	user,
 	actor
 }

--- a/lib/Event/tests/EventBody.spec.jsx
+++ b/lib/Event/tests/EventBody.spec.jsx
@@ -40,7 +40,6 @@ ava.beforeEach((test) => {
 		isMessage: true,
 		editedMessage: null,
 		updating: false,
-		addNotification: sandbox.fake(),
 		messageOverflows: false,
 		setMessageElement: sandbox.fake(),
 		messageCollapsedHeight: 400

--- a/lib/HOC/with-card-updater.js
+++ b/lib/HOC/with-card-updater.js
@@ -8,6 +8,9 @@ import React from 'react'
 import {
 	useSetup
 } from '../SetupProvider'
+import {
+	addNotification
+} from '../services/notifications'
 
 export default function withCardUpdater (skipNotification = false) {
 	return (BaseComponent) => {
@@ -32,13 +35,13 @@ export default function withCardUpdater (skipNotification = false) {
 						})
 						.then((response) => {
 							if (!skipNotification) {
-								actions.addNotification('success', `Updated ${card.name || card.slug}`)
+								addNotification('success', `Updated ${card.name || card.slug}`)
 							}
 							return response
 						})
 						.catch((error) => {
 							console.log(error, error.message)
-							actions.addNotification('danger', error.message || error)
+							addNotification('danger', error.message || error)
 						})
 				}
 				return null

--- a/lib/Timeline/index.jsx
+++ b/lib/Timeline/index.jsx
@@ -29,6 +29,9 @@ import EventsList from './EventsList'
 import PendingMessages from './PendingMessages'
 import TypingNotice from './TypingNotice'
 import {
+	addNotification
+} from '../services/notifications'
+import {
 	UPDATE,
 	CREATE
 } from './constants'
@@ -248,7 +251,7 @@ class Timeline extends React.Component {
 				})
 			})
 			.catch((error) => {
-				this.props.addNotification('danger', error.message || error)
+				addNotification('danger', error.message || error)
 			})
 	}
 
@@ -312,7 +315,7 @@ class Timeline extends React.Component {
 				})
 			})
 			.catch((error) => {
-				this.props.addNotification('danger', error.message || error)
+				addNotification('danger', error.message || error)
 			})
 	}
 
@@ -372,7 +375,6 @@ class Timeline extends React.Component {
 			getCard,
 			enableAutocomplete,
 			eventMenuOptions,
-			addNotification,
 			sdk,
 			types,
 			groups,
@@ -410,9 +412,6 @@ class Timeline extends React.Component {
 			user,
 			selectCard,
 			getCard,
-			actions: {
-				addNotification
-			},
 			threadIsMirrored: isMirrored,
 			menuOptions: eventMenuOptions,
 			getActorHref

--- a/lib/Timeline/tests/helpers.jsx
+++ b/lib/Timeline/tests/helpers.jsx
@@ -85,9 +85,6 @@ const createTestContext = (test, sandbox) => {
 			return sandbox.stub()
 		},
 		getCard: sandbox.stub(),
-		actions: {
-			addNotification: sandbox.stub()
-		},
 		usersTyping: [],
 		user,
 		getActor,

--- a/lib/Timeline/tests/index.spec.jsx
+++ b/lib/Timeline/tests/index.spec.jsx
@@ -131,9 +131,6 @@ ava('A message is not removed from the pendingMessage list until it has been add
 	const createMessage = sandbox.stub()
 	createMessage.resolves()
 
-	const addNotification = sandbox.stub()
-	addNotification.resolves()
-
 	const wrapper = await mount(
 		<Timeline
 			{...eventProps}
@@ -145,7 +142,6 @@ ava('A message is not removed from the pendingMessage list until it has been add
 				}
 			}
 			}
-			addNotification={addNotification}
 		/>, {
 			wrappingComponent: wrapperWithSetup,
 			wrappingComponentProps: {

--- a/lib/services/notifications.js
+++ b/lib/services/notifications.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	notifications
+} from 'rendition'
+import {
+	v4 as uuid
+} from 'uuid'
+
+export const addNotification = (type, content, options = {}) => {
+	const id = options.id || uuid()
+	notifications.addNotification({
+		id, type, content, container: 'bottom-left', ...options
+	})
+	return id
+}
+
+export const removeNotification = (id) => {
+	notifications.removeNotification(id)
+}


### PR DESCRIPTION
Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Use Rendition's `notification` system for Jellyfish notifications.  This simplifies the implementation of notifications in Jellyfish (no more passing the `addNotification` action down to each component that needs it!) and adds a nicer animation effect to the notification items on entry/exit.

Note - this is a major (breaking) change:
* `jellyfish-chat-widget` PR to make use of this is ready [here](https://github.com/product-os/jellyfish-chat-widget/pull/17)
* `jellyfish` PR to make use of this is ready [here](https://github.com/product-os/jellyfish/pull/4607). 

