### PR TITLE
Fix checkFieldAgainstOmissions to ensure that when a key and value are present, we check for both

### DIFF
--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -631,10 +631,17 @@ export const checkFieldAgainstOmissions = (schema, fieldName, omissions) => {
 	return _.some(omissions, ({
 		key, value, field
 	}) => {
-		return (field && fieldName === field) ||
-			// eslint-disable-next-line no-undefined
-			(key && schema[key] !== undefined) ||
-			(value && _.includes(schemaValues, value))
+		const matchesOmittedField = field && fieldName === field
+		if (matchesOmittedField) {
+			return true
+		}
+		const matchesOmittedKey = key && !_.isNil(schema[key])
+		const matchesOmittedValue = value && _.includes(schemaValues, value)
+
+		if (key && value) {
+			return matchesOmittedKey && matchesOmittedValue
+		}
+		return matchesOmittedKey || matchesOmittedValue
 	})
 }
 

--- a/lib/services/helpers.spec.js
+++ b/lib/services/helpers.spec.js
@@ -558,6 +558,27 @@ ava('checkFieldAgainstOmissions matches field schemas against those to be omitte
 	test.true(helpers.checkFieldAgainstOmissions({}, 'version', omissions))
 })
 
+ava('When there are both and key and value present in the omission, checkFieldAgainstOmissions' +
+	' only returns true when the field schema matches both the key and the value', (test) => {
+	const omissions = [ {
+		key: 'length',
+		value: 5
+	} ]
+
+	const firstSchema = {
+		type: 'string',
+		length: 4
+	}
+
+	const secondSchema = {
+		type: 'string',
+		length: 5
+	}
+
+	test.false(helpers.checkFieldAgainstOmissions(firstSchema, 'fakeFieldName', omissions))
+	test.true(helpers.checkFieldAgainstOmissions(secondSchema, 'fakeFieldName', omissions))
+})
+
 ava('checkFieldAgainstOmissions returns false when field schema do not match those to be omitted', async (test) => {
 	const omissions = [ {
 		key: 'pattern'


### PR DESCRIPTION
This is a helper we use to omit certain fields from our table lens and our sort button. You can set a schema with a list of omissions, either by field, key, or value. For example:
```
const omissions = [
  {
    // Omit any field with the name 'id'
    field: 'id'
  },
  {
   //Omit any field that has the 'pattern' key in the schema (this should omit any fields using a regex pattern)
     key: 'pattern'
  },
  {
   // Omit any field that has 'markdown' as a value of any of its keys in the schema (usually format: markdown)
    value: 'markdown'
  }
]
```

This PR updates the helper to check both the key and value match if both are present. For example:

```
const omissions = [{
   key: 'length',
   value: 5
}]
```

Currently this would return true for any field with a length key, even if the value was less or more than 5. With this change, we would also check that the value is 5