### PR TITLE
Add an error boundary to the EventBody component. Render an error message when an error is captured in the component

### DIFF
--- a/lib/Event/EventBody.jsx
+++ b/lib/Event/EventBody.jsx
@@ -120,9 +120,16 @@ export default class EventBody extends React.Component {
 
 		this.expand = () => {
 			this.setState({
-				expanded: !this.state.expanded
+				expanded: !this.state.expanded,
+				hasError: false
 			})
 		}
+	}
+
+	componentDidCatch () {
+		this.setState({
+			hasError: true
+		})
 	}
 
 	render () {
@@ -147,8 +154,24 @@ export default class EventBody extends React.Component {
 			messageCollapsedHeight
 		} = this.props
 		const {
-			expanded
+			expanded,
+			hasError
 		} = this.state
+
+		if (hasError) {
+			return (
+				<MessageContainer
+					data-test="eventBody__errorMessage"
+					ref={setMessageElement}
+					card={card}
+					actor={actor}
+					py={2}
+					px={3}
+					mr={1}
+					error={true}
+				>An error occured while attempting to render this message</MessageContainer>
+			)
+		}
 
 		const message = getMessage(card)
 

--- a/lib/Event/MessageContainer.jsx
+++ b/lib/Event/MessageContainer.jsx
@@ -30,8 +30,14 @@ const MessageContainer = styled(Box) `
 		background-color: #f6f8fa;
 	}
 	${({
-		card, actor, theme, editing
+		card, actor, theme, editing, error
 	}) => {
+		if (error) {
+			return `
+				color: white;
+				background: red;
+			`
+		}
 		if (editing) {
 			return (card.type === 'whisper' || card.type === 'whisper@1.0.0') ? `
 				border: solid 0.5px ${theme.colors.tertiary.light};

--- a/lib/Event/tests/EventBody.spec.jsx
+++ b/lib/Event/tests/EventBody.spec.jsx
@@ -106,3 +106,21 @@ ava('Edited message is shown in markdown if message is being updated', (test) =>
 	const messageText = eventBody.find('[data-test="event-card__message-draft"]')
 	test.is(messageText.props().children.trim(), editedMessage)
 })
+
+ava('An error is captured by the component and an error message is rendered', (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const eventBody = shallow(
+		<EventBody
+			{...commonProps}
+		/>
+	)
+
+	const error = new Error()
+	eventBody.simulateError(error)
+
+	const message = eventBody.find('[data-test="eventBody__errorMessage"]')
+	test.is(message.text(), 'An error occured while attempting to render this message')
+})


### PR DESCRIPTION

![Screenshot from 2020-09-08 13-00-33](https://user-images.githubusercontent.com/6325359/92473704-40789e80-f1db-11ea-8476-c8e882fe8581.png)

Change-type: patch
Signed-off-by: Lucy-Jane Walsh <lucy-jane@balena.io>