### PR TITLE
Use SmartVisibilitySensor for detecting Event visibility

### DIFF
--- a/lib/Event/Event.jsx
+++ b/lib/Event/Event.jsx
@@ -12,11 +12,11 @@ import _ from 'lodash'
 import queryString from 'query-string'
 import * as jsonpatch from 'fast-json-patch'
 import React from 'react'
-import VisibilitySensor from 'react-visibility-sensor'
 import {
 	Box
 }	from 'rendition'
 import styled from 'styled-components'
+import SmartVisibilitySensor from '../SmartVisibilitySensor'
 import * as helpers from '../services/helpers'
 import Avatar from '../shame/Avatar'
 import Icon from '../shame/Icon'
@@ -257,7 +257,7 @@ export default class Event extends React.Component {
 		} = queryString.parse(_.get(location, [ 'search' ], ''))
 
 		return (
-			<VisibilitySensor onChange={this.handleVisibilityChange}>
+			<SmartVisibilitySensor onChange={this.handleVisibilityChange}>
 				<EventWrapper
 					{...rest}
 					squashTop={squashTop}
@@ -344,7 +344,7 @@ export default class Event extends React.Component {
 						/>
 					</Box>
 				</EventWrapper>
-			</VisibilitySensor>
+			</SmartVisibilitySensor>
 		)
 	}
 }

--- a/lib/SmartVisibilitySensor.jsx
+++ b/lib/SmartVisibilitySensor.jsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import VisibilitySensor from 'react-visibility-sensor'
+import {
+	useDocumentVisibility
+} from './hooks'
+
+// Wraps a VisibilitySensor and only calls the 'onChange' callback
+// prop if the underlying element is visible _and_ the document
+// is not currently hidden.
+export default function SmartVisibilitySensor ({
+	onChange, children
+}) {
+	const [ isElementVisible, setIsElementVisible ] = React.useState(false)
+	const isDocumentVisible = useDocumentVisibility()
+
+	React.useEffect(() => {
+		if (isDocumentVisible === null) {
+			// If we can't detect document visibility, just pass on the
+			// visibility sensor's change.
+			onChange(isElementVisible)
+		} else {
+			// Otherwise the child element 'visible' if:
+			//   1. the element is visible in the DOM AND
+			//   2. the document is not hidden
+			onChange(isElementVisible && isDocumentVisible)
+		}
+	}, [ isElementVisible, isDocumentVisible ])
+
+	return (
+		<VisibilitySensor onChange={setIsElementVisible}>
+			{children}
+		</VisibilitySensor>
+	)
+}

--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+export {
+	ResponsiveProvider,
+	withResponsiveContext,
+	useResponsiveContext
+} from './ResponsiveProvider'
+export {
+	default as useDebounce
+} from './use-debounce'
+export {
+	default as useOnClickOutside
+} from './use-onclickoutside'
+export {
+	DocumentVisibilityProvider, useDocumentVisibility
+} from './use-document-visibility'

--- a/lib/hooks/use-document-visibility.js
+++ b/lib/hooks/use-document-visibility.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+
+const documentVisibilityContext = React.createContext(null)
+
+// A React context provider component that acts as a global handler
+// for the document.onvisibilitychange callback.
+export const DocumentVisibilityProvider = ({
+	children
+}) => {
+	const [ isVisible, setIsVisible ] = React.useState(!document.hidden)
+	document.onvisibilitychange = () => {
+		setIsVisible(!document.hidden)
+	}
+	return <documentVisibilityContext.Provider value={isVisible}>{children}</documentVisibilityContext.Provider>
+}
+
+// Returns a boolean value indicating if the document is currently visible
+// This value can be used as the input trigger for a useEffect hook to
+// take action when the document visibility changes.
+export const useDocumentVisibility = () => {
+	return React.useContext(documentVisibilityContext)
+}


### PR DESCRIPTION
Event will only be considered 'visible' if the element is visible AND the document is not hidden.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Relates to: [@mentions are being marked read when the browser tab is inactive](https://github.com/product-os/jellyfish/issues/4687)

Note: This change is _not_ breaking as without the `DocumentVisibilityProvider` component in the component tree, the behaviour of the `SmartVisibiltySensor` is identical to the underlying `VisibilitySensor`.

_I tried adding a unit test for the  `DocumentVisibilityProvider` and `SmartVisibiltySensor` components but the `VisibilitySensor` component does not work with the mocked browser environment._