### PR TITLE
Ignore meta-data tokens inside code blocks in message

### DIFF
--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -590,13 +590,17 @@ export const userDisplayName = (user) => {
 	return user.name || user.slug.replace('user-', '')
 }
 
+// Matches all multi-line and inline code blocks
+const CODE_BLOCK_REGEXP = new RegExp(/`{1,3}[^`]*`{1,3}/, 'g')
+
 export const getMessageMetaData = (message) => {
+	const sanitizedMessage = message.replace(CODE_BLOCK_REGEXP, '')
 	return {
-		mentionsUser: getSlugsByPrefix('@', message, 'user-'),
-		alertsUser: getSlugsByPrefix('!', message, 'user-'),
-		mentionsGroup: getSlugsByPrefix('@@', message),
-		alertsGroup: getSlugsByPrefix('!!', message),
-		tags: findWordsByPrefix('#', message).map((tag) => {
+		mentionsUser: getSlugsByPrefix('@', sanitizedMessage, 'user-'),
+		alertsUser: getSlugsByPrefix('!', sanitizedMessage, 'user-'),
+		mentionsGroup: getSlugsByPrefix('@@', sanitizedMessage),
+		alertsGroup: getSlugsByPrefix('!!', sanitizedMessage),
+		tags: findWordsByPrefix('#', sanitizedMessage).map((tag) => {
 			return tag.slice(1).toLowerCase()
 		})
 	}

--- a/lib/services/helpers.spec.js
+++ b/lib/services/helpers.spec.js
@@ -579,6 +579,47 @@ ava('When there are both and key and value present in the omission, checkFieldAg
 	test.true(helpers.checkFieldAgainstOmissions(secondSchema, 'fakeFieldName', omissions))
 })
 
+ava.only('getMessageMetaData ignores tokens in code blocks and inline code', async (test) => {
+	const defaultExpectedTokens = [ '0', '2', '4' ]
+	const defaultMetaData = {
+		mentionsUser: [],
+		alertsUser: [],
+		mentionsGroup: [],
+		alertsGroup: [],
+		tags: []
+	}
+	const generateMessage = (tokenPrefix) => {
+		return [
+			`Testing ${tokenPrefix}0}`,
+			'```',
+			`Code block 1 ${tokenPrefix}1}`,
+			'```',
+			`Testing ${tokenPrefix}2`,
+			'```',
+			`Code block 2 ${tokenPrefix}3`,
+			'```',
+			`Testing ${tokenPrefix}4`,
+			`Inline code \`y = 0; ${tokenPrefix}5\``
+		].join('\n')
+	}
+	const testToken = (tokenPrefix, metaDataField, expectedTokens = defaultExpectedTokens) => {
+		const metaData = helpers.getMessageMetaData(generateMessage(tokenPrefix))
+		const expectedMetaData = {
+			...defaultMetaData,
+			[metaDataField]: expectedTokens
+		}
+		test.deepEqual(metaData, expectedMetaData)
+	}
+	const withUserPrefix = (token) => {
+		return `user-${token}`
+	}
+	testToken('#', 'tags')
+	testToken('@', 'mentionsUser', defaultExpectedTokens.map(withUserPrefix))
+	testToken('!', 'alertsUser', defaultExpectedTokens.map(withUserPrefix))
+	testToken('@@', 'mentionsGroup')
+	testToken('!!', 'alertsGroup')
+})
+
 ava('checkFieldAgainstOmissions returns false when field schema do not match those to be omitted', async (test) => {
 	const omissions = [ {
 		key: 'pattern'


### PR DESCRIPTION
Any tokens inside code blocks will not be used when parsing meta-data from a message. i.e you can @ mention someone or add a hashtag in a code block and it will not be added to the meta data of the message card.

Note - this does not affect the _rendering_ of these tokens in the message body. This will be addressed in a separate PR.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Fixes [Jellyfish issue 2417](https://github.com/product-os/jellyfish/issues/2417)