### PR TITLE
Mentions component: Do not assume groups exists

### DIFF
--- a/lib/Event/Mention.jsx
+++ b/lib/Event/Mention.jsx
@@ -19,7 +19,7 @@ export const highlightTags = (element, readBy, username, groups) => {
 	}
 
 	const trimmed = text.replace(prefixRE, '').toLowerCase()
-	const group = groups[trimmed]
+	const group = groups && groups[trimmed]
 
 	if (group && group.isMine) {
 		element.className += ' rendition-tag--personal'


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Small fix for handling the situation where the groups object passed to `highlightTags` is null or undefined.