### PR TITLE
Prevent user sending blank messages

### DIFF
--- a/lib/Timeline/index.jsx
+++ b/lib/Timeline/index.jsx
@@ -263,7 +263,8 @@ class Timeline extends React.Component {
 	}
 
 	addMessage (newMessage, whisper) {
-		if (!newMessage) {
+		const trimmedMessage = newMessage.trim()
+		if (!trimmedMessage) {
 			return
 		}
 		this.props.setTimelineMessage(this.props.card.id, '')
@@ -273,7 +274,7 @@ class Timeline extends React.Component {
 			mentionsGroup,
 			alertsGroup,
 			tags
-		} = helpers.getMessageMetaData(newMessage)
+		} = helpers.getMessageMetaData(trimmedMessage)
 		const message = {
 			target: this.props.card,
 			type: whisper ? 'whisper' : 'message',
@@ -284,7 +285,7 @@ class Timeline extends React.Component {
 				alertsUser,
 				mentionsGroup,
 				alertsGroup,
-				message: helpers.replaceEmoji(newMessage.replace(messageSymbolRE, ''))
+				message: helpers.replaceEmoji(trimmedMessage.replace(messageSymbolRE, ''))
 			}
 		}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

---

Strip leading and trailing whitespace and new line and carriage return characters before sending a message. If the trimmed message is blank - don't do anything!

Fixes [Jellyfish issue 4740](https://github.com/product-os/jellyfish/issues/4740)