### PR TITLE
New UserAvatar component

### DIFF
--- a/lib/UserAvatar/index.jsx
+++ b/lib/UserAvatar/index.jsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import styled from 'styled-components'
+import _ from 'lodash'
+import {
+	Avatar,
+	Flex
+} from 'rendition'
+import CardLoader from '../CardLoader'
+import UserStatusIcon from '../UserStatusIcon'
+import {
+	generateActorFromUserCard
+} from '../services/helpers'
+
+const dimensions = ({
+	emphasized
+}) => {
+	const top = emphasized ? -4 : -2
+	return `
+		.user-status-icon {
+			top: ${top}px;
+			right: -2px;
+		}
+	`
+}
+
+const Wrapper = styled(Flex) `
+	position: relative;
+	.user-status-icon {
+		position: absolute;
+	}
+	box-sizing: content-box;
+	${dimensions}
+`
+
+export const UserAvatar = React.memo(({
+	userId, selectCard, getCard, emphasized, ...rest
+}) => {
+	return (
+		<CardLoader
+			id={userId}
+			type="user"
+			withLinks={[ 'is member of' ]}
+			cardSelector={selectCard}
+			getCard={getCard}
+		>
+			{(user) => {
+				const actor = generateActorFromUserCard(user)
+				return (
+					<Wrapper
+						tooltip={_.truncate(`${actor.name} (${actor.email})`, 30)}
+						emphasized={emphasized}
+						{...rest}
+					>
+						<Avatar
+							emphasized={emphasized}
+							firstName={_.get(user, [ 'data', 'profile', 'name', 'first' ])}
+							lastName={_.get(user, [ 'data', 'profile', 'name', 'last' ])}
+							src={_.get(user, [ 'data', 'avatar' ])}
+						/>
+						<UserStatusIcon
+							className="user-status-icon"
+							small={!emphasized}
+							userStatus={_.get(user, [ 'data', 'status' ])}
+						/>
+					</Wrapper>
+				)
+			}}
+		</CardLoader>
+	)
+})

--- a/lib/UserAvatar/tests/UserAvatar.spec.jsx
+++ b/lib/UserAvatar/tests/UserAvatar.spec.jsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getWrapper
+} from '../../../test/ui-setup'
+import ava from 'ava'
+import sinon from 'sinon'
+import {
+	mount
+} from 'enzyme'
+import React from 'react'
+import userWithOrg from './fixtures/user-with-org.json'
+import {
+	UserAvatar
+} from '../'
+
+const wrappingComponent = getWrapper().wrapper
+
+const sandbox = sinon.createSandbox()
+
+ava.beforeEach((test) => {
+	test.context = {
+		...test.context,
+		commonProps: {
+			emphasized: false,
+			userId: userWithOrg.id,
+			getCard: sandbox.stub(),
+			selectCard: sandbox.stub().returns(() => {
+				return userWithOrg
+			})
+		}
+	}
+	sandbox.restore()
+})
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('UserAvatar displays the user`s avatar, tooltip and status', async (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const component = await mount((
+		<UserAvatar {...commonProps} />
+	), {
+		wrappingComponent
+	})
+
+	const avatar = component.find('AvatarBase')
+	test.false(avatar.props().emphasized)
+	test.is(avatar.props().firstName, 'Test')
+	test.is(avatar.props().lastName, 'User')
+	test.is(avatar.props().src, 'https://via.placeholder.com/150')
+
+	const statusIcon = component.find('UserStatusIcon')
+	test.is(statusIcon.props().small, !commonProps.emphasized)
+	test.deepEqual(statusIcon.props().userStatus.value, 'DoNotDisturb')
+
+	const wrapper = component.find('Box').first()
+	test.is(wrapper.props().tooltip, 'Test User (test@jel.ly.fish)')
+})

--- a/lib/UserAvatar/tests/fixtures/user-with-org.json
+++ b/lib/UserAvatar/tests/fixtures/user-with-org.json
@@ -1,0 +1,59 @@
+{
+  "id": "8c20804f-f11e-44eb-a69e-d21de4c18444",
+  "data": {
+    "hash": "$2b$12$9uFeuGjg3uCrY770kZQ7L.StRLOkceibIQ6gIY5ei25RgR4PYvoyC",
+    "email": "test@jel.ly.fish",
+    "roles": [
+      "user-test"
+    ],
+    "status": {
+      "title": "Do Not Disturb",
+      "value": "DoNotDisturb"
+    },
+    "avatar": "https://via.placeholder.com/150",
+    "profile": {
+      "name": {
+        "last": "User",
+        "first": "Test"
+      },
+      "about": {}
+    }
+  },
+  "name": "Test User",
+  "slug": "user-jellyfish",
+  "tags": [],
+  "type": "user@1.0.0",
+  "links": {
+    "is member of": [
+      {
+        "id": "203eda41-d593-48cf-b4d1-0e72b6443508",
+        "data": {},
+        "name": "Balena",
+        "slug": "org-balena",
+        "tags": [],
+        "type": "org@1.0.0",
+        "links": {},
+        "active": true,
+        "markers": [],
+        "version": "1.0.0",
+        "requires": [],
+        "linked_at": {
+          "has member": "2020-10-20T02:25:53.741Z"
+        },
+        "created_at": "2020-10-20T02:25:51.508Z",
+        "updated_at": null,
+        "capabilities": []
+      }
+    ]
+  },
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {
+    "is member of": "2020-10-20T02:25:53.741Z"
+  },
+  "created_at": "2020-10-20T02:25:53.172Z",
+  "updated_at": "2020-10-21T07:01:16.349Z",
+  "capabilities": []
+}

--- a/lib/UserStatusIcon.jsx
+++ b/lib/UserStatusIcon.jsx
@@ -70,9 +70,7 @@ export default function UserStatusIcon ({
 			{...props}
 			alignItems="center"
 			justifyContent="center"
-			tooltip={{
-				text: userStatus.title, placement: 'right'
-			}}
+			tooltip={userStatus.title}
 		>
 			{ statusIconName && <Icon name={statusIconName} /> }
 		</StatusWrapper>


### PR DESCRIPTION
Uses Rendition Avatar component and lazy-loads the user card.

Future PRs will make use of this component in the Event and CardChatSummary components.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Relates to: #4619

Note - there's no visual difference between the current `shame/Avatar` component and this one - apart from the fact that there is now a tooltip that displays the name and email.

The reason for the slightly clunky `CardLoader` usage is that this ensures that if/when the corresponding user card is updated in the redux store, it will force the `UserAvatar` to get updated too (for example when they turn on/off Do Not Disturb).