### PR TITLE
Add owner, created at, last message avatar to CardChatSummary

### DIFF
--- a/lib/CardChatSummary/MessageSnippet.jsx
+++ b/lib/CardChatSummary/MessageSnippet.jsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import _ from 'lodash'
+import {
+	Flex,
+	Link
+} from 'rendition'
+import {
+	Markdown
+} from 'rendition/dist/extra/Markdown'
+import {
+	UserAvatar
+} from '../UserAvatar'
+import CardLoader from '../CardLoader'
+import MessageContainer from '../Event/MessageContainer'
+import {
+	HIDDEN_ANCHOR
+} from '../Timeline'
+import {
+	generateActorFromUserCard
+} from '../services/helpers'
+
+const componentOverrides = {
+	img: (attribs) => {
+		return <span>[{attribs.title || attribs.alt || 'image'}]</span>
+	},
+	// eslint-disable-next-line id-length
+	a: (attribs) => {
+		// The whole chat summary is clickable. Prevent navigating to the
+		// chat/thread channel when clicking on a link within the last message
+		// summary.
+		const onClick = (event) => {
+			event.stopPropagation()
+			event.preventDefault()
+			window.open(attribs.href)
+		}
+		return <Link blank {...attribs} onClick={onClick} />
+	}
+}
+
+export const MessageSnippet = React.memo(({
+	messageCard, selectCard, getCard, ...rest
+}) => {
+	if (!messageCard) {
+		return null
+	}
+
+	const messageText = React.useMemo(() => {
+		return _.get(messageCard, [ 'data', 'payload', 'message' ], '')
+			.replace(/```[^`]*```/, '`<code block>`')
+			.split('\n')
+			.map((line) => {
+				return line.includes(HIDDEN_ANCHOR) ? '[image]' : line
+			})
+			.shift()
+	}, [ messageCard ])
+
+	const userId = _.get(messageCard, [ 'data', 'actor' ])
+
+	return (
+		<CardLoader
+			id={userId}
+			type="user"
+			withLinks={[ 'is member of' ]}
+			cardSelector={selectCard}
+			getCard={getCard}
+		>
+			{(user) => {
+				const actor = generateActorFromUserCard(user)
+				return (
+					<Flex alignItems="flex-start" {...rest}>
+						<UserAvatar
+							userId={userId}
+							selectCard={selectCard}
+							getCard={getCard}
+						/>
+						<MessageContainer
+							truncated
+							flex={1}
+							card={messageCard}
+							actor={actor}
+							squashTop={false}
+							squashBottom={false}
+							py={2}
+							px={3}
+							ml={2}
+							mr={-3}
+						>
+							<Markdown
+								data-test="card-chat-summary__message"
+								componentOverrides={componentOverrides}
+							>
+								{messageText}
+							</Markdown>
+						</MessageContainer>
+					</Flex>
+				)
+			}}
+		</CardLoader>
+	)
+})

--- a/lib/CardChatSummary/OwnerDisplay.jsx
+++ b/lib/CardChatSummary/OwnerDisplay.jsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import {
+	Flex
+} from 'rendition'
+import {
+	UserAvatar
+} from '../UserAvatar'
+import Icon from '../shame/Icon'
+
+export const OwnerDisplay = ({
+	owner, selectCard, getCard, ...rest
+}) => {
+	if (!owner) {
+		return null
+	}
+	return (
+		<Flex
+			{...rest}
+			alignItems="center"
+			tooltip={`Owned by ${owner.name || owner.slug}`}
+		>
+			<Icon name="user" regular />
+			<UserAvatar
+				ml={2}
+				userId={owner.id}
+				selectCard={selectCard}
+				getCard={getCard}
+			/>
+		</Flex>
+	)
+}

--- a/lib/CardChatSummary/TimeSummary.jsx
+++ b/lib/CardChatSummary/TimeSummary.jsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import React from 'react'
+import styled from 'styled-components'
+import {
+	Flex,
+	Txt
+} from 'rendition'
+import Icon from '../shame/Icon'
+import {
+	timeAgo
+} from '../services/helpers'
+
+const SingleLine = styled(Txt) `
+	white-space: nowrap;
+`
+
+export const TimeSummary = React.memo(({
+	prefix, timestamp, iconName, ...rest
+}) => {
+	return (
+		<Flex
+			{...rest}
+			alignItems="center"
+			tooltip={`${prefix} ${timeAgo(timestamp)}`}
+		>
+			<Icon name={iconName} />
+			<SingleLine ml={2} fontSize={12}>{timeAgo(timestamp, true)}</SingleLine>
+		</Flex>
+	)
+})

--- a/lib/CardChatSummary/tests/MessageSnippet.spec.jsx
+++ b/lib/CardChatSummary/tests/MessageSnippet.spec.jsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import {
+	getWrapper
+} from '../../../test/ui-setup'
+import ava from 'ava'
+import {
+	mount
+} from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import msg from './fixtures/msg-text.json'
+import userWithOrg from './fixtures/user2.json'
+import {
+	MessageSnippet
+} from '../MessageSnippet'
+
+const wrappingComponent = getWrapper().wrapper
+
+const sandbox = sinon.createSandbox()
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('MessageSnippet displays the user avatar and the message text', async (test) => {
+	const selectCard = sandbox.stub().returns(() => {
+		return userWithOrg
+	})
+	const getCard = sandbox.stub()
+	const component =	await mount((
+		<MessageSnippet
+			messageCard={msg}
+			selectCard={selectCard}
+			getCard={getCard}
+		/>
+	), {
+		wrappingComponent
+	})
+
+	// The UserStatusIcon is part of the user avatar component
+	const userStatusIcon = component.find('UserStatusIcon')
+	test.is(userStatusIcon.props().userStatus.value, 'DoNotDisturb')
+
+	const txt = component.find('p').first()
+	test.is(txt.text(), msg.data.payload.message)
+})

--- a/lib/CardChatSummary/tests/OwnerDisplay.spec.jsx
+++ b/lib/CardChatSummary/tests/OwnerDisplay.spec.jsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import '../../../test/ui-setup'
+import ava from 'ava'
+import {
+	shallow
+} from 'enzyme'
+import sinon from 'sinon'
+import React from 'react'
+import userWithOrg from './fixtures/user2.json'
+import {
+	OwnerDisplay
+} from '../OwnerDisplay'
+
+const sandbox = sinon.createSandbox()
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
+
+ava('OwnerDisplay displays the user avatar and the message text', async (test) => {
+	const selectCard = sandbox.stub().returns(() => {
+		return userWithOrg
+	})
+	const getCard = sandbox.stub()
+	const component =	shallow(
+		<OwnerDisplay
+			owner={userWithOrg}
+			selectCard={selectCard}
+			getCard={getCard}
+		/>
+	)
+
+	const userIcon = component.find('Icon')
+	test.is(userIcon.props().name, 'user')
+
+	const avatar = component.find('Memo()')
+	test.is(avatar.props().userId, userWithOrg.id)
+})

--- a/lib/CardChatSummary/tests/TimeSummary.spec.jsx
+++ b/lib/CardChatSummary/tests/TimeSummary.spec.jsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import '../../../test/ui-setup'
+import ava from 'ava'
+import {
+	shallow
+} from 'enzyme'
+import React from 'react'
+import moment from 'moment'
+import {
+	TimeSummary
+} from '../TimeSummary'
+
+const prefix = 'Created'
+const timestamp = moment().subtract(2, 'd').toISOString()
+const iconName = 'history'
+
+ava('TimeSummary displays the icon, tooltip and timeago text', (test) => {
+	const component =	shallow(
+		<TimeSummary
+			prefix={prefix}
+			timestamp={timestamp}
+			iconName={iconName}
+		/>
+	)
+
+	const wrapper = component.find('Flex')
+	test.is(wrapper.props().tooltip, 'Created 2 days ago')
+
+	const icon = component.find('Icon')
+	test.is(icon.props().name, iconName)
+
+	const txt = component.find('Styled(Txt)')
+	test.is(txt.text(), '2 days')
+})

--- a/lib/CardChatSummary/tests/fixtures/msg-text.json
+++ b/lib/CardChatSummary/tests/fixtures/msg-text.json
@@ -1,0 +1,26 @@
+{
+  "id": "0155c3c7-d971-4ddc-a5e9-1600ca985965",
+  "data": {
+    "actor": "f4db7498-c8a8-48f0-9d8a-a11591a2576e",
+    "target": "598b9691-d3e4-47f4-a18c-00a3cab25a2f",
+    "payload": {
+      "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    },
+    "timestamp": "2020-10-20T07:43:27.079Z"
+  },
+  "name": null,
+  "slug": "message-a78678a3-825a-4398-a27e-f127f5e1994f",
+  "tags": [],
+  "type": "message@1.0.0",
+  "links": {},
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
+  "linked_at": {
+    "is attached to": "2020-10-20T07:43:27.380Z"
+  },
+  "created_at": "2020-10-20T07:43:27.170Z",
+  "updated_at": null,
+  "capabilities": []
+}

--- a/lib/CardChatSummary/tests/fixtures/user2.json
+++ b/lib/CardChatSummary/tests/fixtures/user2.json
@@ -1,22 +1,59 @@
 {
-  "id": "99eb9304-96a7-4350-9360-c4bdf8c2e99c",
-  "slug": "user-testuser",
-  "type": "user",
-  "active": true,
-  "version": "1.0.0",
-  "name": null,
-  "tags": [],
-  "markers": [],
-  "created_at": "2019-05-31T09:40:03.330Z",
-  "links": {},
-  "requires": [],
-  "capabilities": [],
+  "id": "f4db7498-c8a8-48f0-9d8a-a11591a2576e",
   "data": {
-    "email": "testuser@example.com"
+    "hash": "$2b$12$MKXG2JOJxg93u3Au3T/OkuXmWh9LPyAmy.81yEFWEujX1RBjjcnH6",
+    "email": "johndoe-d4d4b974-7aab-4c4b-a524-fe2ecea5e085@example.com",
+    "roles": [
+      "user-community"
+    ],
+    "status": {
+      "title": "Do Not Disturb",
+      "value": "DoNotDisturb"
+    },
+    "avatar": "https://via.placeholder.com/150",
+    "profile": {
+      "name": {
+        "last": "User",
+        "first": "Test"
+      },
+      "about": {}
+    }
   },
-  "updated_at": null,
+  "name": null,
+  "slug": "user-johndoe-9519fa60-9cc4-45d0-94d9-f079f5893cbe",
+  "tags": [],
+  "type": "user@1.0.0",
+  "links": {
+    "is member of": [
+      {
+        "id": "203eda41-d593-48cf-b4d1-0e72b6443508",
+        "data": {},
+        "name": "Balena",
+        "slug": "org-balena",
+        "tags": [],
+        "type": "org@1.0.0",
+        "links": {},
+        "active": true,
+        "markers": [],
+        "version": "1.0.0",
+        "requires": [],
+        "linked_at": {
+          "has member": "2020-10-20T02:25:53.741Z"
+        },
+        "created_at": "2020-10-20T02:25:51.508Z",
+        "updated_at": null,
+        "capabilities": []
+      }
+    ]
+  },
+  "active": true,
+  "markers": [],
+  "version": "1.0.0",
+  "requires": [],
   "linked_at": {
-    "is member of": "2019-05-31T09:40:03.516Z",
-    "has attached element": "2019-05-31T09:40:03.438Z"
-  }
+    "is member of": "2020-10-20T07:43:22.080Z"
+  },
+  "created_at": "2020-10-20T07:43:21.052Z",
+  "updated_at": "2020-10-20T07:43:21.627Z",
+  "capabilities": []
 }

--- a/lib/Event/MessageContainer.jsx
+++ b/lib/Event/MessageContainer.jsx
@@ -10,7 +10,8 @@ import {
 } from 'rendition'
 
 const MessageContainer = styled(Box) `
-	border-radius: 6px;
+	min-width: 0;
+	border-radius: 12px;
 	border-top-left-radius: 0;
 	box-shadow: -5px 4.5px 10.5px 0 rgba(152, 173, 227, 0.08);
 	a {
@@ -94,8 +95,24 @@ const MessageContainer = styled(Box) `
 				border-bottom-left-radius: 0;
 				border-bottom-color: transparent;
 			` : ''
-	}
-}}
+	}}
+
+	${({
+		truncated
+	}) => {
+		return truncated ? `
+			border-right-width: 0;
+			border-top-right-radius: 0;
+			border-bottom-right-radius: 0;
+			p {
+				line-height: 1.2;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+		` : ''
+	}}
+}
 `
 
 export default MessageContainer

--- a/lib/UserAvatar/index.jsx
+++ b/lib/UserAvatar/index.jsx
@@ -51,9 +51,10 @@ export const UserAvatar = React.memo(({
 		>
 			{(user) => {
 				const actor = generateActorFromUserCard(user)
+				const tooltip = actor && `${_.truncate(actor.name, 30)}\n${_.truncate(actor.email, 30)}`
 				return (
 					<Wrapper
-						tooltip={_.truncate(`${actor.name} (${actor.email})`, 30)}
+						tooltip={tooltip}
 						emphasized={emphasized}
 						{...rest}
 					>

--- a/lib/UserAvatar/tests/UserAvatar.spec.jsx
+++ b/lib/UserAvatar/tests/UserAvatar.spec.jsx
@@ -63,5 +63,5 @@ ava('UserAvatar displays the user`s avatar, tooltip and status', async (test) =>
 	test.deepEqual(statusIcon.props().userStatus.value, 'DoNotDisturb')
 
 	const wrapper = component.find('Box').first()
-	test.is(wrapper.props().tooltip, 'Test User (test@jel.ly.fish)')
+	test.is(wrapper.props().tooltip, 'Test User\ntest@jel.ly.fish')
 })

--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -134,8 +134,8 @@ export const formatTimestamp = _.memoize((stamp, prefix = false) => {
 	return stamp
 })
 
-export const timeAgo = (stamp) => {
-	return moment(stamp).fromNow()
+export const timeAgo = (stamp, withoutSuffix = false) => {
+	return moment(stamp).fromNow(withoutSuffix)
 }
 
 // Only consider objects with $eval
@@ -457,6 +457,13 @@ export const getCreator = async (getActorFn, card) => {
 	}
 	const actor = await getActorFn(_.get(createCard, [ 'data', 'actor' ]))
 	return actor
+}
+
+export const getCreateCard = (card) => {
+	const attachedCards = _.get(card.links, [ 'has attached element' ], [])
+	return _.find(attachedCards, (attachedCard) => {
+		return attachedCard.type.split('@')[0] === 'create'
+	})
 }
 
 export const getLastUpdate = (card) => {


### PR DESCRIPTION
Breaking change - need to add selectCard and getCard props to CardChatSummary instances.

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>
***

![New CardChatSummary](https://user-images.githubusercontent.com/2925657/96829269-7d36e700-1463-11eb-91b7-2762801c41d0.gif)

The message snippet now uses the same styling as the message in the timeline - so you can easily tell if it is a whisper or message or message from a non-balena user.

Implemented based on [these mockups](https://zpl.io/bl9XJ7z)