### PR TITLE
Handle discourse attachments with a special case

### DIFF
--- a/lib/Event/EventBody.jsx
+++ b/lib/Event/EventBody.jsx
@@ -49,6 +49,7 @@ const StyledMarkdown = styled(Markdown)(({
 	}
 })
 
+const DISCOURSE_ATTACHMENT_RE = /\[(.+?)\|attachment\]\(upload:\/\/(.+?\..+?)\)/g
 const FRONT_MARKDOWN_IMG_RE = /\[\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+\]/g
 const FRONT_HTML_IMG_RE = /\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+/g
 const IMAGE_URL_RE = /^https?:\/\/.*\.(?:png|jpg|gif)(?:\?\S*)*$/
@@ -87,6 +88,14 @@ export const getMessage = (card) => {
 				1,
 				-1
 			)})`
+		})
+	}
+
+	// Fun hack to convert inline attachments from synced Discourse messages into
+	// markdown links
+	if (message.match(DISCOURSE_ATTACHMENT_RE)) {
+		return message.replace(DISCOURSE_ATTACHMENT_RE, (link, filename, urlPrefix) => {
+			return `[${filename}](https://forums.balena.io/uploads/short-url/${urlPrefix})`
 		})
 	}
 

--- a/lib/Event/tests/EventBody.spec.jsx
+++ b/lib/Event/tests/EventBody.spec.jsx
@@ -24,6 +24,17 @@ import {
 const wrappingComponent = getWrapper().wrapper
 const sandbox = sinon.createSandbox()
 
+const getMessageInCard = (message) => {
+	const newCard = _.merge(card, {
+		data: {
+			payload: {
+				message
+			}
+		}
+	})
+	return getMessage(newCard)
+}
+
 ava.beforeEach((test) => {
 	test.context.commonProps = {
 		enableAutocomplete: false,
@@ -50,22 +61,22 @@ ava.afterEach(() => {
 	sandbox.restore()
 })
 
+ava.only('getMessage replaces inline Discourse attachment links with correct markdown links', (test) => {
+	const msg = getMessageInCard(
+		'This is a link: [file1.log|attachment](upload://2NTd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB) ' +
+		'This is another link: [file2.log|attachment](upload://4EDd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB)'
+	)
+	test.is(msg,
+		'This is a link: [file1.log](https://forums.balena.io/uploads/short-url/2NTd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB) ' +
+		'This is another link: [file2.log](https://forums.balena.io/uploads/short-url/4EDd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB)')
+})
+
 ava('getMessage detects a message that only contains an image url and wraps it', (test) => {
 	const jpgURL = 'http://test.com/image.jpg?some-data=2'
 	const pngURL = 'http://test.co.uk/image%20again.png?some-data=+2'
 	const gifURL = 'https://wwww.test.com/image.gif'
 	const imageMessage = (url) => {
 		return `![image](${url})`
-	}
-	const getMessageInCard = (message) => {
-		const newCard = _.merge(card, {
-			data: {
-				payload: {
-					message
-				}
-			}
-		})
-		return getMessage(newCard)
 	}
 	test.is(getMessageInCard(jpgURL), imageMessage(jpgURL))
 	test.is(getMessageInCard(pngURL), imageMessage(pngURL))


### PR DESCRIPTION
This should mean that messages synced from Discourse which contain inline attachments are rendered correctly with the attachment as a link.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Closes https://github.com/product-os/jellyfish/issues/4782
