### PR TITLE
Debounce async select data fetching

### DIFF
--- a/lib/AutoCompleteWidget.jsx
+++ b/lib/AutoCompleteWidget.jsx
@@ -67,7 +67,7 @@ class AutoCompleteWidget extends React.Component {
 	constructor (props) {
 		super(props)
 
-		this.getTargets = this.getTargets.bind(this)
+		this.getTargets = _.debounce(this.getTargets.bind(this), 500)
 		this.onChange = this.onChange.bind(this)
 	}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This PR improves the performance of the `AutoCompleteWidget` by debouncing the query to search for matching entries.