### PR TITLE
Fix rendering of inline Discourse images

### DIFF
--- a/lib/Event/EventBody.jsx
+++ b/lib/Event/EventBody.jsx
@@ -49,6 +49,7 @@ const StyledMarkdown = styled(Markdown)(({
 	}
 })
 
+const DISCOURSE_IMAGE_RE = /!\[(.+?)\|\d*x\d*\]\(upload:\/\/(.+?\..+?)\)/g
 const FRONT_MARKDOWN_IMG_RE = /\[\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+\]/g
 const FRONT_HTML_IMG_RE = /\/api\/1\/companies\/resin_io\/attachments\/[a-z0-9]+\?resource_link_id=\d+/g
 const IMAGE_URL_RE = /^https?:\/\/.*\.(?:png|jpg|gif)(?:\?\S*)*$/
@@ -70,6 +71,14 @@ export const getMessage = (card) => {
 
 	if (message.trim().match(IMAGE_URL_RE)) {
 		return `![image](${message.trim()})`
+	}
+
+	// Fun hack to extract attached screenshots from synced Discourse messages
+	// into markdown images
+	if (message.match(DISCOURSE_IMAGE_RE)) {
+		return message.replace(DISCOURSE_IMAGE_RE, (link, filename, urlPrefix) => {
+			return `![${filename}](https://forums.balena.io/uploads/short-url/${urlPrefix})`
+		})
 	}
 
 	// Fun hack to extract attached images embedded in HTML from synced front messages

--- a/lib/Event/tests/EventBody.spec.jsx
+++ b/lib/Event/tests/EventBody.spec.jsx
@@ -24,6 +24,17 @@ import {
 const wrappingComponent = getWrapper().wrapper
 const sandbox = sinon.createSandbox()
 
+const getMessageInCard = (message) => {
+	const newCard = _.merge(card, {
+		data: {
+			payload: {
+				message
+			}
+		}
+	})
+	return getMessage(newCard)
+}
+
 ava.beforeEach((test) => {
 	test.context.commonProps = {
 		enableAutocomplete: false,
@@ -50,22 +61,22 @@ ava.afterEach(() => {
 	sandbox.restore()
 })
 
+ava('getMessage replaces inline Discourse images with correct markdown images', (test) => {
+	const msg = getMessageInCard(
+		'This is an inline image: ![file1.log|600x400](upload://2NTd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB) ' +
+		'This is another inline image: ![file2.log|64x48](upload://4EDd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB)'
+	)
+	test.is(msg,
+		'This is an inline image: ![file1.log](https://forums.balena.io/uploads/short-url/2NTd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB) ' +
+		'This is another inline image: ![file2.log](https://forums.balena.io/uploads/short-url/4EDd93eaDOQohgCHeMpUr5cynbL.log) (149.6 KB)')
+})
+
 ava('getMessage detects a message that only contains an image url and wraps it', (test) => {
 	const jpgURL = 'http://test.com/image.jpg?some-data=2'
 	const pngURL = 'http://test.co.uk/image%20again.png?some-data=+2'
 	const gifURL = 'https://wwww.test.com/image.gif'
 	const imageMessage = (url) => {
 		return `![image](${url})`
-	}
-	const getMessageInCard = (message) => {
-		const newCard = _.merge(card, {
-			data: {
-				payload: {
-					message
-				}
-			}
-		})
-		return getMessage(newCard)
 	}
 	test.is(getMessageInCard(jpgURL), imageMessage(jpgURL))
 	test.is(getMessageInCard(pngURL), imageMessage(pngURL))


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This should mean that messages synced from Discourse which contain inline images are rendered correctly as markdown images.

Closes https://github.com/product-os/jellyfish/issues/4102