### PR TITLE
error-reporter: Add info logs

### DIFF
--- a/lib/services/error-reporter.js
+++ b/lib/services/error-reporter.js
@@ -45,4 +45,19 @@ export default class Reporter {
 			})
 		}
 	}
+
+	reportInfo (message, data) {
+		if (this.initialized) {
+			Sentry.withScope((scope) => {
+				if (data) {
+					Object.keys(data).forEach((key) => {
+						scope.setExtra(key, JSON.stringify(data[key]))
+					})
+				}
+
+				scope.setLevel('info')
+				Sentry.captureMessage(message)
+			})
+		}
+	}
 }


### PR DESCRIPTION
Change-type: minor

Adds `errorReporter.reportInfo` method which sends message to sentry. These messages have "info" level and look different on sentry (you can filter out info logs).

<img width="633" alt="Screen Shot 2020-11-06 at 3 13 08 PM" src="https://user-images.githubusercontent.com/2152815/98360043-9aaea800-2042-11eb-87aa-272bc2d2fdbc.png">
