### PR TITLE
Fix react-textarea-autosize ref value

### DIFF
--- a/lib/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
+++ b/lib/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
@@ -101,7 +101,7 @@ const SubAuto = (props) => {
 				innerRef={innerRefCallback}
 				textAreaComponent={{
 					component: TextareaAutosize,
-					ref: 'inputRef'
+					ref: 'ref'
 				}}
 				className={className}
 				value={value}


### PR DESCRIPTION
This was not picked up when we updated react-textarea-autosize to v8 in jellyfish-ui-components v5.1.3

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

See the [react-textarea-autosize changelog](https://github.com/Andarist/react-textarea-autosize/blob/master/CHANGELOG.md#major-changes) for details.