### PR TITLE
Add username to tooltip in message header

### DIFF
--- a/lib/Event/Message/Header.jsx
+++ b/lib/Event/Message/Header.jsx
@@ -69,6 +69,8 @@ export default class EventHeader extends React.Component {
 
 		const isOwnMessage = user.id === _.get(card, [ 'data', 'actor' ])
 
+		const actorTooltip = actor ? `${_.castArray(actor.email)[0]} (${actor.card.slug.slice(5)})` : 'loading...'
+
 		return (
 			<HeaderWrapper justifyContent="space-between">
 				<Flex
@@ -81,7 +83,7 @@ export default class EventHeader extends React.Component {
 					{(!squashTop && isMessage) && (
 						<Txt
 							data-test="event__actor-label"
-							tooltip={actor ? actor.email : 'loading...'}
+							tooltip={actorTooltip}
 						>
 							{Boolean(actor) && Boolean(actor.card) && (() => {
 								const text = <Txt.span color="black">{actor.name}</Txt.span>


### PR DESCRIPTION
Also fixes the problem where if a user has multiple email addresses they are not rendered in the tooltip.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Before:
![image](https://user-images.githubusercontent.com/2925657/99504884-b73bd000-29b2-11eb-9d8d-ce320b8e418d.png)

After:
![image](https://user-images.githubusercontent.com/2925657/99504833-a68b5a00-29b2-11eb-8674-fcd304f3a5b7.png)
