### PR TITLE
Fix order of exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,10 @@
 import * as constants from './constants'
 
 export {
+	Link,
+	getLinkProps
+} from './Link'
+export {
 	helpers,
 	timezones,
 	Analytics,
@@ -96,10 +100,6 @@ export {
 export {
 	InfiniteList
 } from './InfiniteList'
-export {
-	Link,
-	getLinkProps
-} from './Link'
 export {
 	LinksProvider, withLink, withLinks, useLink, useLinks
 } from './LinksProvider'


### PR DESCRIPTION
This fixes a circular dependency issue in unit tests.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>