### PR TITLE
Do not show hidden front URLs in messages

### DIFF
--- a/lib/CardChatSummary/MessageSnippet.jsx
+++ b/lib/CardChatSummary/MessageSnippet.jsx
@@ -18,11 +18,13 @@ import {
 import CardLoader from '../CardLoader'
 import MessageContainer from '../Event/Message/MessageContainer'
 import {
+	RE_FRONT_HIDDEN_URL
+} from '../Event/Message'
+import {
 	HIDDEN_ANCHOR
 } from '../Timeline'
 import {
-	Link,
-	getLinkProps
+	linkComponentOverride
 } from '../Link'
 import {
 	getMessage,
@@ -34,12 +36,9 @@ const componentOverrides = {
 		return <span>[{attribs.title || attribs.alt || 'image'}]</span>
 	},
 	// eslint-disable-next-line id-length
-	a: ({
-		href, ...rest
-	}) => {
-		const linkProps = getLinkProps(href)
-		return <Link {...rest} {...linkProps} />
-	}
+	a: linkComponentOverride({
+		blacklist: [ RE_FRONT_HIDDEN_URL ]
+	})
 }
 
 export const MessageSnippet = React.memo(({

--- a/lib/CardChatSummary/tests/MessageSnippet.spec.jsx
+++ b/lib/CardChatSummary/tests/MessageSnippet.spec.jsx
@@ -7,6 +7,7 @@
 import {
 	getWrapper
 } from '../../../test/ui-setup'
+import _ from 'lodash'
 import ava from 'ava'
 import {
 	mount
@@ -48,4 +49,32 @@ ava('MessageSnippet displays the user avatar and the message text', async (test)
 
 	const txt = component.find('p').first()
 	test.is(txt.text(), msg.data.payload.message)
+})
+
+ava('MessageSnippet does not display hidden front URLs', async (test) => {
+	const selectCard = sandbox.stub().returns(() => {
+		return userWithOrg
+	})
+	const getCard = sandbox.stub()
+
+	const frontCard = _.merge({}, msg, {
+		data: {
+			payload: {
+				message: 'Line1[](https://www.balena-cloud.com?hidden=whisper&source=flowdock)'
+			}
+		}
+	})
+
+	const component =	await mount((
+		<MessageSnippet
+			messageCard={frontCard}
+			selectCard={selectCard}
+			getCard={getCard}
+		/>
+	), {
+		wrappingComponent
+	})
+
+	const txt = component.find('p').first()
+	test.is(txt.text(), 'Line1')
 })

--- a/lib/Event/Message/Body.jsx
+++ b/lib/Event/Message/Body.jsx
@@ -23,8 +23,7 @@ import {
 import Attachments from './Attachments'
 import Mention from './Mention'
 import {
-	Link,
-	getLinkProps
+	linkComponentOverride
 } from '../../Link'
 import * as helpers from '../../services/helpers'
 import ErrorBoundary from '../../shame/ErrorBoundary'
@@ -51,6 +50,12 @@ const StyledMarkdown = styled(Markdown)(({
 		overflow: messageOverflows ? 'hidden' : 'initial'
 	}
 })
+
+/*
+ * This message text is added by Front when syncing whispers. It should be hidden in the message
+* text in Jellyfish.
+ */
+export const RE_FRONT_HIDDEN_URL = /https:\/\/www\.balena-cloud\.com\?hidden=whisper.*/
 
 const DISCOURSE_IMAGE_RE = /!\[(.+?)\|\d*x\d*\]\(upload:\/\/(.+?\..+?)\)/g
 const DISCOURSE_ATTACHMENT_RE = /\[(.+?)\|attachment\]\(upload:\/\/(.+?\..+?)\)/g
@@ -123,12 +128,9 @@ const componentOverrides = {
 		return <Img {...attribs} style={IMG_STYLE} />
 	},
 	// eslint-disable-next-line id-length
-	a: ({
-		href, ...rest
-	}) => {
-		const linkProps = getLinkProps(href)
-		return <Link {...rest} {...linkProps} />
-	},
+	a: linkComponentOverride({
+		blacklist: [ RE_FRONT_HIDDEN_URL ]
+	}),
 	mention: (attribs) => {
 		return <Mention {...attribs} />
 	}

--- a/lib/Event/Message/index.jsx
+++ b/lib/Event/Message/index.jsx
@@ -32,6 +32,10 @@ import {
 	isTimelineEvent
 } from '../../helpers'
 
+export {
+	RE_FRONT_HIDDEN_URL
+} from './Body'
+
 const MESSAGE_COLLAPSED_HEIGHT = 400
 
 const EventButton = styled.button `

--- a/lib/Event/Message/tests/EventBody.spec.jsx
+++ b/lib/Event/Message/tests/EventBody.spec.jsx
@@ -7,6 +7,7 @@
 import {
 	getWrapper
 } from '../../../../test/ui-setup'
+import _ from 'lodash'
 import ava from 'ava'
 import sinon from 'sinon'
 import {
@@ -102,4 +103,30 @@ ava('An error is captured by the component and an error message is rendered', (t
 
 	const message = eventBody.first('div[data-test="eventBody__errorMessage"]')
 	test.is(message.text(), 'An error occured while attempting to render this message')
+})
+
+ava('Hidden front URLs are not displayed in the message', (test) => {
+	const {
+		commonProps
+	} = test.context
+
+	const frontCard = _.merge({}, card, {
+		data: {
+			payload: {
+				message: 'Line1\n[](https://www.balena-cloud.com?hidden=whisper&source=flowdock)'
+			}
+		}
+	})
+
+	const eventBody = mount(
+		<Body
+			{...commonProps}
+			card={frontCard}
+		/>
+		, {
+			wrappingComponent
+		})
+
+	const message = eventBody.first('[data-test="event-card__message"]')
+	test.is(message.text().trim(), 'Line1')
 })

--- a/lib/Link/Link.jsx
+++ b/lib/Link/Link.jsx
@@ -32,6 +32,22 @@ export const getLinkProps = (href) => {
 		}
 }
 
+export const linkComponentOverride = ({
+	blacklist
+}) => {
+	return ({
+		href, ...rest
+	}) => {
+		if (_.some(blacklist, (url) => {
+			return href.match(url)
+		})) {
+			return null
+		}
+		const linkProps = getLinkProps(href)
+		return <Link {...rest} {...linkProps} />
+	}
+}
+
 export class Link extends React.Component {
 	constructor (props) {
 		super(props)

--- a/lib/Link/index.jsx
+++ b/lib/Link/index.jsx
@@ -12,7 +12,8 @@ import {
 } from './Link'
 
 export {
-	getLinkProps
+	getLinkProps,
+	linkComponentOverride
 } from './Link'
 
 export const Link = withRouter(InnerLink)


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

These URLs do not resolve and should never show up in Jellyfish UI (but should be kept in the message body).

Fixes #5299

Note - the whole way we handle parsing/filtering messages needs a bit of an overhaul/re-think. Keen to hear people's suggestions for a cleaner way to handle this. The complication/ugly bit at the moment is that we display message text differently in the message snippet and in the message body.

Before: 
![image](https://user-images.githubusercontent.com/2925657/101720788-0e782080-3ad9-11eb-9de2-b52a335b65f9.png)

After:
![image](https://user-images.githubusercontent.com/2925657/101720840-336c9380-3ad9-11eb-9d53-7f12b6ffde14.png)
