### PR TITLE
Fix Link component references

### DIFF
--- a/lib/Link/Link.jsx
+++ b/lib/Link/Link.jsx
@@ -10,43 +10,6 @@ import React from 'react'
 import {
 	Link as RenditionLink
 } from 'rendition'
-import {
-	isRelativeUrl,
-	isLocalUrl,
-	toRelativeUrl
-} from '../services/helpers'
-
-export const getLinkProps = (href) => {
-	if (isRelativeUrl(href)) {
-		return {
-			append: href.replace(/^\//, '')
-		}
-	}
-	return (isLocalUrl(href))
-		? {
-			append: toRelativeUrl(href).replace(/^\//, '')
-		}
-		: {
-			to: href,
-			blank: true
-		}
-}
-
-export const linkComponentOverride = ({
-	blacklist
-}) => {
-	return ({
-		href, ...rest
-	}) => {
-		if (_.some(blacklist, (url) => {
-			return href.match(url)
-		})) {
-			return null
-		}
-		const linkProps = getLinkProps(href)
-		return <Link {...rest} {...linkProps} />
-	}
-}
 
 export class Link extends React.Component {
 	constructor (props) {

--- a/lib/Link/Link.spec.jsx
+++ b/lib/Link/Link.spec.jsx
@@ -14,9 +14,11 @@ import {
 	mount
 } from 'enzyme'
 import {
-	Link,
-	getLinkProps
+	Link
 } from './Link'
+import {
+	getLinkProps
+} from './index'
 
 const sandbox = sinon.createSandbox()
 

--- a/lib/Link/index.jsx
+++ b/lib/Link/index.jsx
@@ -4,16 +4,50 @@
  * Proprietary and confidential.
  */
 
+import React from 'react'
+import _ from 'lodash'
 import {
 	withRouter
 } from 'react-router-dom'
 import {
 	Link as InnerLink
 } from './Link'
-
-export {
-	getLinkProps,
-	linkComponentOverride
-} from './Link'
+import {
+	isRelativeUrl,
+	isLocalUrl,
+	toRelativeUrl
+} from '../services/helpers'
 
 export const Link = withRouter(InnerLink)
+
+export const getLinkProps = (href) => {
+	if (isRelativeUrl(href)) {
+		return {
+			append: href.replace(/^\//, '')
+		}
+	}
+	return (isLocalUrl(href))
+		? {
+			append: toRelativeUrl(href).replace(/^\//, '')
+		}
+		: {
+			to: href,
+			blank: true
+		}
+}
+
+export const linkComponentOverride = ({
+	blacklist
+}) => {
+	return ({
+		href, ...rest
+	}) => {
+		if (_.some(blacklist, (url) => {
+			return href.match(url)
+		})) {
+			return null
+		}
+		const linkProps = getLinkProps(href)
+		return <Link {...rest} {...linkProps} />
+	}
+}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes a bug introduced in #259 that causes messages with links to jel.ly.fish to not render.

(the componentOverride was using the `Link` component without the `withRouter` HOC wrapper - so the `location` prop was not available).