### PR TITLE
Omni search helpers

### DIFF
--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -435,9 +435,11 @@ export const regexEscape = (str) => {
 
 // TODO normalize this with the text search created by Rendition Filters
 export const createFullTextSearchFilter = (schema, term) => {
+	let hasFullTextSearchField = false
 	const flatSchema = SchemaSieve.flattenSchema(schema)
-	const stringKeys = _.reduce(flatSchema.properties, (carry, item, key) => {
+	let stringKeys = _.reduce(flatSchema.properties, (carry, item, key) => {
 		if (item.type === 'string' || (_.isArray(item.type) && _.includes(item.type, 'string'))) {
+			hasFullTextSearchField = hasFullTextSearchField || Boolean(item.fullTextSearch)
 			carry.push({
 				key,
 				fullTextSearch: Boolean(item.fullTextSearch)
@@ -445,6 +447,12 @@ export const createFullTextSearchFilter = (schema, term) => {
 		}
 		return carry
 	}, [])
+
+	// If any fullTextSearch field is found, we will only search these fields,
+	// otherwise we'll fall-back to searching all regexp fields.
+	if (hasFullTextSearchField) {
+		stringKeys = _.filter(stringKeys, 'fullTextSearch')
+	}
 
 	// A schema that matches applies the pattern to each schema field with a type
 	// of 'string'

--- a/lib/services/helpers.spec.js
+++ b/lib/services/helpers.spec.js
@@ -221,6 +221,24 @@ ava('.createFullTextSearchFilter() uses fullTextSearch on properties with the \'
 	test.is(filter.anyOf[0].properties.title.fullTextSearch.term, searchTerm)
 })
 
+ava('.createFullTextSearchFilter() only filters on fullTextSearch fields if any \'fullTextSearch\' field found', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			title: {
+				type: 'string',
+				fullTextSearch: true
+			},
+			description: {
+				type: 'string'
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm)
+	test.is(filter.anyOf.length, 1)
+	test.is(filter.anyOf[0].properties.title.fullTextSearch.term, searchTerm)
+})
+
 ava('.createFullTextSearchFilter() works on deeply nested objects', (test) => {
 	const searchTerm = 'test'
 	const schema = {


### PR DESCRIPTION
One new and one modified helper method that will be useful for omni-search.

Main change is this:
>If _any_ fullTextSearch field is found, we will _only_ search these fields, otherwise we'll fall-back to searching all regexp fields.

***

Add getMergedSchema helper method

This will be used in various places in the front-end code.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

createFullTextSearchFilter searches for fullTextSearch _or_ regexp

If any fullTextSearch field is found, we will only search these fields, otherwise we'll fall-back to searching all regexp fields.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***
