### PR TITLE
Add fullTextSearchFieldsOnly optional argument to createFullTextSearchFilter

### DIFF
--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -434,7 +434,20 @@ export const regexEscape = (str) => {
 }
 
 // TODO normalize this with the text search created by Rendition Filters
-export const createFullTextSearchFilter = (schema, term) => {
+
+/**
+ * Returns a filter schema that can be used to search for cards based on the given
+ * schema and search term.
+ *
+ * @param {Object} schema - the type card's schema. This will define searchable fields.
+ * @param {String} term - the search term to search for
+ * @param {Boolean} fullTextSearchFieldsOnly - (default: false) if set, a null object will
+ * be returned if no fullTextSearch fields are found.
+ *
+ * @returns {Object | null} - the filter schema, or null if no fullTextSearch fields are found
+ * and fullTextSearchFieldsOnly is true.
+ */
+export const createFullTextSearchFilter = (schema, term, fullTextSearchFieldsOnly = false) => {
 	let hasFullTextSearchField = false
 	const flatSchema = SchemaSieve.flattenSchema(schema)
 	let stringKeys = _.reduce(flatSchema.properties, (carry, item, key) => {
@@ -452,6 +465,8 @@ export const createFullTextSearchFilter = (schema, term) => {
 	// otherwise we'll fall-back to searching all regexp fields.
 	if (hasFullTextSearchField) {
 		stringKeys = _.filter(stringKeys, 'fullTextSearch')
+	} else if (fullTextSearchFieldsOnly) {
+		return null
 	}
 
 	// A schema that matches applies the pattern to each schema field with a type

--- a/lib/services/helpers.spec.js
+++ b/lib/services/helpers.spec.js
@@ -257,6 +257,19 @@ ava('.createFullTextSearchFilter() works on deeply nested objects', (test) => {
 	test.is(filter.anyOf[0].properties.title.properties.label.regexp.pattern, searchTerm)
 })
 
+ava('.createFullTextSearchFilter() returns null if no fullTextSearch fields and fullTextSearchFieldsOnly is set', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			title: {
+				type: 'string'
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm, true)
+	test.is(filter, null)
+})
+
 // TODO: Unskip this test once we fix the flattening of arrays.
 ava.skip('.createFullTextSearchFilter() works on arrays of strings', (test) => {
 	const searchTerm = 'test'


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This will be used by omni-search to restrict searches to types that define at least one fullTextSearch field.