### PR TITLE
Only search for fullTextSearch fields on quick search

### DIFF
--- a/lib/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
+++ b/lib/shame/AutocompleteTextarea/AutocompleteTextarea.jsx
@@ -178,7 +178,15 @@ class AutoCompleteArea extends React.Component {
 	}
 
 	loadResults (typeCard, value) {
-		const filter = helpers.createFullTextSearchFilter(typeCard.data.schema, value)
+		const filter = helpers.createFullTextSearchFilter(typeCard.data.schema, value, {
+			fullTextSearchFieldsOnly: true
+		})
+		if (!filter) {
+			this.setState({
+				results: []
+			})
+			return
+		}
 		_.set(filter, [ 'properties', 'type' ], {
 			type: 'string',
 			const: `${typeCard.slug}@${typeCard.version}`


### PR DESCRIPTION
When searching for cards using the message input's quick search, only filter on `fullTextSearch: true` fields. If no there are no such fields in the schema, return an empty results set.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Part of a series of PRs that move us towards only searching on indexed fields.