### PR TITLE
Allow a view to explicitly define the types it is interested in

### DIFF
--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -94,6 +94,11 @@ const getTypesFromSchema = (schema) => {
 export const getTypesFromViewCard = (card) => {
 	let value = []
 
+	// First check if the view has explicitly declared types
+	if (!_.isEmpty(card.data.types)) {
+		return _.castArray(card.data.types)
+	}
+
 	if (card.data.allOf) {
 		for (const item of card.data.allOf) {
 			let found = getTypesFromSchema(item.schema)

--- a/lib/services/helpers.spec.js
+++ b/lib/services/helpers.spec.js
@@ -872,6 +872,32 @@ ava('toRelativeUrl converts absolute URLs to relative URLs', (test) => {
 	test.is(helpers.toRelativeUrl('http://www.example.com/test'), '/test')
 })
 
+ava('getTypesFromViewCard prioritizes the types defined in a view card\'s types property', (test) => {
+	test.deepEqual(
+		helpers.getTypesFromViewCard({
+			slug: 'view-1',
+			type: 'view@1.0.0',
+			data: {
+				types: [ 'type2@1.0.0' ],
+				allOf: [
+					{
+						schema: {
+							type: 'object',
+							properties: {
+								type: {
+									type: 'string',
+									const: 'type1@1.0.0'
+								}
+							}
+						}
+					}
+				]
+			}
+		}),
+		[ 'type2@1.0.0' ]
+	)
+})
+
 ava('getTypesFromViewCard returns the const type defined in a view card\'s allOf', (test) => {
 	test.deepEqual(
 		helpers.getTypesFromViewCard({


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This will be useful for omni-search where, for performance reasons, it is useful to not define the types as an enum in the view's filter - but still specify them in the view so that the view lens can still make use of the tail type as necessary.

Note - this functionality was already present in the `getTypeFromViewCard` helper method that returned a single type. But it was accidentally omitted when creating the equivalent `getTypesFromViewCard` method that returns an array of types.