### PR TITLE
Fix paragraph spacing in messages

### DIFF
--- a/lib/Event/Message/MessageContainer.jsx
+++ b/lib/Event/Message/MessageContainer.jsx
@@ -9,6 +9,7 @@ import {
 	Box
 } from 'rendition'
 import {
+	px,
 	isPrivateTimelineEvent
 } from '../../services/helpers'
 
@@ -17,6 +18,12 @@ const MessageContainer = styled(Box) `
 	border-radius: 12px;
 	border-top-left-radius: 0;
 	box-shadow: -5px 4.5px 10.5px 0 rgba(152, 173, 227, 0.08);
+	p {
+		padding-bottom: ${(props) => { return px(props.theme.space[2]) }};
+	}
+	p:last-child {
+		padding-bottom: 0;
+	}
 	a {
 		color: inherit;
 		text-decoration: underline;


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes https://github.com/product-os/jellyfish/issues/5639
Fixes https://github.com/product-os/jellyfish/issues/5754

This has been broken since [this Rendition commit](https://github.com/balena-io-modules/rendition/commit/2a5aa535c48336a3c1471470887e7dc51e6544fd). I've just set the bottom padding for the paragraphs in Jellyfish messages.


Before:
![image](https://user-images.githubusercontent.com/2925657/108959077-7a186580-76a6-11eb-8fdd-49eed8209fe1.png)

After:
![image](https://user-images.githubusercontent.com/2925657/108959101-843a6400-76a6-11eb-9417-ca554ea810f3.png)
