### PR TITLE
Add includeIdAndSlug option for createFullTextSearchFilter

### DIFF
--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -486,6 +486,8 @@ const getSearchableFieldQuerySchema = (item, term) => {
  * @param {Object} options - optional options
  * @param {Boolean} options.fullTextSearchFieldsOnly - (default: false) if set, a null object will
  * be returned if no fullTextSearch fields are found.
+ * @param {Boolean} options.includeIdAndSlug - (default: false) if set, the id and slug fields are
+ * automatically included (as regexp searches)
  *
  * @returns {Object | null} - the filter schema, or null if no fullTextSearch fields are found
  * and fullTextSearchFieldsOnly is true.
@@ -508,7 +510,7 @@ export const createFullTextSearchFilter = (schema, term, options = {}) => {
 	// otherwise we'll fall-back to searching all regexp fields.
 	if (hasFullTextSearchField) {
 		stringKeys = _.filter(stringKeys, 'item.fullTextSearch')
-	} else if (options.fullTextSearchFieldsOnly) {
+	} else if (options.fullTextSearchFieldsOnly && !options.includeIdAndSlug) {
 		return null
 	}
 
@@ -525,6 +527,26 @@ export const createFullTextSearchFilter = (schema, term, options = {}) => {
 					[key]: getSearchableFieldQuerySchema(item, term)
 				},
 				required: [ key ]
+			}
+		})
+	}
+
+	if (options.includeIdAndSlug) {
+		[ 'id', 'slug' ].forEach((key) => {
+			// Only add these options if they are not already present
+			if (!_.find(filter.anyOf, (anyOfOption) => {
+				return _.has(anyOfOption, [ 'properties', key ])
+			})) {
+				filter.anyOf.push({
+					type: 'object',
+					properties: {
+						[key]: {
+							// Note: we are not interested in matching against partial IDs or slugs
+							const: term
+						}
+					},
+					required: [ key ]
+				})
 			}
 		})
 	}

--- a/lib/services/helpers.spec.js
+++ b/lib/services/helpers.spec.js
@@ -207,6 +207,76 @@ ava('.createFullTextSearchFilter() uses regex on properties where the type array
 	test.is(filter.anyOf[0].properties.title.regexp.pattern, searchTerm)
 })
 
+ava('.createFullTextSearchFilter() includes ID and Slug if the includeIdAndSlugs option is set', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			title: {
+				type: 'string'
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm, {
+		includeIdAndSlug: true
+	})
+	test.is(filter.anyOf.length, 3)
+	test.truthy(_.find(filter.anyOf, {
+		properties: {
+			title: {
+				regexp: {
+					pattern: searchTerm
+				}
+			}
+		}
+	}))
+	test.truthy(_.find(filter.anyOf, {
+		properties: {
+			id: {
+				const: searchTerm
+			}
+		}
+	}))
+	test.truthy(_.find(filter.anyOf, {
+		properties: {
+			slug: {
+				const: searchTerm
+			}
+		}
+	}))
+})
+
+ava('.createFullTextSearchFilter() only creates one filter for slug if the includeIdAndSlugs option is set', (test) => {
+	const searchTerm = 'test'
+	const schema = {
+		properties: {
+			slug: {
+				type: 'string',
+				fullTextSearch: true
+			}
+		}
+	}
+	const filter = helpers.createFullTextSearchFilter(schema, searchTerm, {
+		includeIdAndSlug: true
+	})
+	test.is(filter.anyOf.length, 2)
+	test.truthy(_.find(filter.anyOf, {
+		properties: {
+			id: {
+				const: searchTerm
+			}
+		}
+	}))
+	test.truthy(_.find(filter.anyOf, {
+		properties: {
+			slug: {
+				fullTextSearch: {
+					term: searchTerm
+				}
+			}
+		}
+	}))
+})
+
 ava('.createFullTextSearchFilter() uses fullTextSearch on string properties with the \'fullTextSearch\' field set', (test) => {
 	const searchTerm = 'test'
 	const schema = {


### PR DESCRIPTION
This is a convenience option for those situations where you also want to search the ID or slug of the card (in full).

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This is a pre-requisite for searching for cards to link/unlink by ID or slug. Once this is in place we can also modify the LinkModal code to allow the user to paste in a JF URL to a card and extract the ID/slug from the URL (i.e. use just the last segment of the URL) and use that as the search term.
