### PR TITLE
Export JellyfishLink component

### DIFF
--- a/lib/Link/index.jsx
+++ b/lib/Link/index.jsx
@@ -36,6 +36,12 @@ export const getLinkProps = (href) => {
 		}
 }
 
+export const JellyfishLink = ({
+	href, ...rest
+}) => {
+	return <Link {...rest} {...getLinkProps(href)} />
+}
+
 export const linkComponentOverride = ({
 	blacklist
 }) => {
@@ -47,7 +53,6 @@ export const linkComponentOverride = ({
 		})) {
 			return null
 		}
-		const linkProps = getLinkProps(href)
-		return <Link {...rest} {...linkProps} />
+		return <JellyfishLink {...rest} href={href} />
 	}
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@
 import * as constants from './constants'
 
 export {
+	JellyfishLink,
 	Link,
 	getLinkProps
 } from './Link'


### PR DESCRIPTION
This component wraps the Link component and coverts the href prop into the correct combination of append, to and blank. Relative or local URLs are appended to the current path, while any other URLs will open in a new tab.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This is the first step towards adding a `JellyfishLink` Renderer widget, which will address [this issue](https://github.com/product-os/jellyfish/issues/5901).