### PR TITLE
Fix call to username helper method

### DIFF
--- a/lib/Event/Message/Header.jsx
+++ b/lib/Event/Message/Header.jsx
@@ -42,7 +42,7 @@ export default class EventHeader extends React.Component {
 			if (typeBase === 'user') {
 				return (
 					<Txt color={Theme.colors.text.light}>
-						<strong>{username(targetCard)}</strong> joined
+						<strong>{username(targetCard.slug)}</strong> joined
 					</Txt>
 				)
 			}


### PR DESCRIPTION
Need to pass in the slug, not the whole card.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>