### PR TITLE
Scroll to newly received message if required

### DIFF
--- a/lib/Timeline/index.jsx
+++ b/lib/Timeline/index.jsx
@@ -366,9 +366,7 @@ class Timeline extends React.Component {
 
 	scrollToBottom () {
 		if (this.timelineEnd.current) {
-			this.timelineEnd.current.scrollIntoView({
-				behavior: 'smooth'
-			})
+			this.timelineEnd.current.scrollIntoView()
 		}
 	}
 


### PR DESCRIPTION
Scroll to newly received message if required

Do not scroll if not previously at the bottom of the list.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fixes https://github.com/product-os/jellyfish/issues/5948
