### PR TITLE
Change card links to point to specific version

### DIFF
--- a/lib/services/helpers.js
+++ b/lib/services/helpers.js
@@ -59,6 +59,22 @@ export const pathWithoutChannel = (channel) => {
 	return pathWithoutTarget(channel.data.target)
 }
 
+/**
+ * Returns the best available (human readable) reference to a card.
+ *
+ * Priority is defined like this:
+ * versioned slug > slug > version
+ *
+ * @param {Object} card - The card to reference
+ * @returns {String} a reference to the card
+ */
+export const cardReference = (card) => {
+	if (card.slug && card.version) {
+		return `${card.slug}@${card.version}`
+	}
+	return card.slug || card.id
+}
+
 export const appendToChannelPath = (channel, card) => {
 	const parts = []
 	const	pieces = window.location.pathname.split('/')
@@ -71,7 +87,7 @@ export const appendToChannelPath = (channel, card) => {
 		}
 	}
 
-	parts.push(card.slug || card.id)
+	parts.push(cardReference(card))
 
 	const route = Reflect.apply(path.join, null, parts)
 


### PR DESCRIPTION
This fixes links to cards that are not @1.0.0

Depends-on https://github.com/product-os/jellyfish/pull/6077

Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>