### PR TITLE
Prevent file upload messages displaying extra empty message container

### DIFF
--- a/lib/event/message/body.tsx
+++ b/lib/event/message/body.tsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import _ from 'lodash';
 import styled from 'styled-components';
 import { Button, Txt, Img } from 'rendition';
 import { Markdown } from 'rendition/dist/extra/Markdown';
@@ -166,6 +167,8 @@ const Body = (props: any) => {
 
 	const message = parseMessage(helpers.getMessage(card));
 
+	const isJustFile = !message && _.get(card, ['data', 'payload', 'file']);
+
 	const decorators = React.useMemo(() => {
 		return [
 			{
@@ -191,7 +194,7 @@ const Body = (props: any) => {
 				squashTop={squashTop}
 				squashBottom={squashBottom}
 			/>
-			{isMessage && (
+			{isMessage && !isJustFile && (
 				<MessageContainer
 					ref={setMessageElement}
 					card={card}

--- a/lib/event/message/tests/event-body.spec.tsx
+++ b/lib/event/message/tests/event-body.spec.tsx
@@ -9,11 +9,37 @@ import _ from 'lodash';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 import React from 'react';
+import { SetupProvider } from '../../../setup-provider';
 import Body from '../body';
 import { card } from './fixtures';
+import { JellyfishSDK } from '@balena/jellyfish-client-sdk';
+import { Analytics } from '../../../services';
 
 const wrappingComponent = getWrapper().wrapper;
 const sandbox = sinon.createSandbox();
+
+const { wrapper: Wrapper } = getWrapper({
+	core: {},
+});
+
+const wrapperWithSetup = ({
+	children,
+	sdk,
+	analytics,
+}: {
+	children: React.ReactNode;
+	sdk: JellyfishSDK;
+	analytics: Analytics;
+}) => {
+	return (
+		<Wrapper>
+			{/* @ts-ignore: TS-TODO - add missing props to SetupProvider test instance */}
+			<SetupProvider sdk={sdk} analytics={analytics}>
+				{children}
+			</SetupProvider>
+		</Wrapper>
+	);
+};
 
 const context: any = {};
 
@@ -27,7 +53,9 @@ beforeEach(() => {
 		user: {
 			slug: 'test-user',
 		},
-		sdk: {},
+		sdk: {
+			getFile: sandbox.stub().resolves('abc'),
+		},
 		card,
 		actor: {},
 		isMessage: true,
@@ -110,4 +138,43 @@ test('Hidden front URLs are not displayed in the message', () => {
 
 	const message = eventBody.first('[data-test="event-card__message"]');
 	expect(message.text().trim()).toBe('Line1');
+});
+
+test('Messages with file attachments and no text content only display the file attachment', () => {
+	const { commonProps } = context;
+
+	const fileUploadCard = _.merge({}, card, {
+		data: {
+			payload: {
+				file: {
+					mime: 'image/jpeg',
+					name: 'test.jpg',
+					slug: '5c0844ce-929c-4c4c-86d6-5c381a1dd811.test.jpg',
+					bytesize: 795366,
+				},
+				message:
+					'[](#jellyfish-hidden)A file has been uploaded using Jellyfish: http://localhost:9000/5dab83ea-c9b0-4698-aaee-e063bd871e80',
+			},
+		},
+	});
+
+	const eventBody: any = mount(
+		<Body {...commonProps} card={fileUploadCard} />,
+		{
+			wrappingComponent: wrapperWithSetup,
+			wrappingComponentProps: {
+				sdk: commonProps.sdk,
+				analytics: {
+					track: sandbox.stub(),
+				},
+			},
+		},
+	);
+
+	const image = eventBody.find(
+		'AuthenticatedImage[data-test="event-card__image"]',
+	);
+	expect(image.length).toBe(1);
+	const message = eventBody.find('div[data-test="event-card__message"]');
+	expect(message.length).toBe(0);
 });


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Fixes https://github.com/product-os/jellyfish/issues/6014

Before:
![image](https://user-images.githubusercontent.com/2925657/119442389-f415c480-bd51-11eb-8671-6b774d8d5f5b.png)

After:
![image](https://user-images.githubusercontent.com/2925657/119442135-78b41300-bd51-11eb-8264-4db17bcb6fcf.png)

(Note: we should also fix the bottom padding - but I'll leave this for another PR as it's all tied in with different message types and consecutive messages from the same user etc)
