### PR TITLE
Expose enumNames for view slices

### DIFF
--- a/lib/services/helpers.ts
+++ b/lib/services/helpers.ts
@@ -477,6 +477,7 @@ export const getViewSlices = (view: core.ViewContract, types: string[]) => {
 				title,
 				path: slice,
 				values: subSchema.enum,
+				names: subSchema.enumNames,
 			};
 		});
 	}


### PR DESCRIPTION
This will allow us to display enum names (if specified) rather than enum values in the Jellyfish UI for slice options.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>