### PR TITLE
CardChatSummary: Add support for last message field in contract

### DIFF
--- a/lib/CardChatSummary/index.tsx
+++ b/lib/CardChatSummary/index.tsx
@@ -112,19 +112,21 @@ export class CardChatSummary extends React.Component<any, any> {
 
 		const { actor } = this.state;
 
-		const latestMessageCard = _.findLast(timeline, (event) => {
-			const typeBase = event.type.split('@')[0];
-			return typeBase === 'message' || typeBase === 'whisper';
-		});
+		const lastMessage = _.get(card, ['data', 'lastMessage']);
+
+		const latestMessageCard =
+			lastMessage && !_.isEmpty(lastMessage)
+				? lastMessage
+				: _.findLast(timeline, (event) => {
+						const typeBase = helpers.getTypeBase(event.type);
+						return typeBase === 'message' || typeBase === 'whisper';
+				  });
 
 		const createdTime = _.get(helpers.getCreateCard(card), [
 			'data',
 			'timestamp',
 		]);
-		const updatedTime = _.get(helpers.getLastUpdate(card), [
-			'data',
-			'timestamp',
-		]);
+		const updatedTime = _.get(latestMessageCard, ['data', 'timestamp']);
 
 		const threadOwner = _.get(card.links, ['is owned by', 0]);
 

--- a/lib/CardChatSummary/tests/CardChatSummary.spec.tsx
+++ b/lib/CardChatSummary/tests/CardChatSummary.spec.tsx
@@ -15,6 +15,7 @@ import card from './fixtures/card.json';
 import inlineImageMsg from './fixtures/msg-inline-image.json';
 import user1 from './fixtures/user-1.json';
 import user2 from './fixtures/user-2.json';
+import { helpers } from '../../services';
 
 const sandbox = sinon.createSandbox();
 
@@ -67,6 +68,36 @@ test('It should render', () => {
 	expect(() => {
 		shallow(<CardChatSummary {...commonProps} />);
 	}).not.toThrow();
+});
+
+test('It should use the lastMessage field on the card, if set', async () => {
+	const { commonProps } = context;
+
+	const lastMessage = _.findLast(commonProps.timeline, (event) => {
+		const typeBase = helpers.getTypeBase(event.type);
+		return typeBase === 'message' || typeBase === 'whisper';
+	});
+
+	const cardWithLastMessage = _.merge({}, commonProps.card, {
+		data: {
+			lastMessage,
+		},
+	});
+
+	const props = {
+		..._.omit(commonProps, 'card', 'timeline'),
+		card: cardWithLastMessage,
+	};
+
+	const component = await mount(<CardChatSummary {...props} />, {
+		wrappingComponent,
+	});
+
+	const messageSummary = component.find(
+		'div[data-test="card-chat-summary__message"]',
+	);
+	const messageSummaryText = messageSummary.text();
+	expect(messageSummaryText.trim()).toBe(lastMessage.data.payload.message);
 });
 
 test('It should change the actor after an update', async () => {


### PR DESCRIPTION
If the lastMessage field is populated, use that for the latest message card. Otherwise fall back to using the provided timeline. In due course the lastMessage field should always be populated and we can remove support for the timeline prop.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>