### PR TITLE
Make rendition a peer dependency

### DIFF
--- a/lib/services/helpers.ts
+++ b/lib/services/helpers.ts
@@ -611,7 +611,7 @@ export const createFullTextSearchFilter = (
 		fullTextSearchFieldsOnly?: boolean;
 		includeIdAndSlug?: boolean;
 	} = {},
-) => {
+): JSONSchema | null => {
 	let hasFullTextSearchField = false;
 	const flatSchema = SchemaSieve.flattenSchema(schema);
 	let stringKeys = _.reduce(

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "UNLICENSED",
   "peerDependencies": {
-    "@balena/jellyfish-client-sdk": "^6.0.0"
+    "@balena/jellyfish-client-sdk": "^6.0.0",
+    "rendition": "^21.7.16"
   },
   "dependencies": {
     "@sentry/browser": "^6.13.2",
@@ -77,7 +78,6 @@
     "react-textarea-autosize": "^8.3.3",
     "react-visibility-sensor": "^5.1.1",
     "redux": "^4.1.1",
-    "rendition": "^21.7.16",
     "skhema": "^5.3.4",
     "styled-components": "^5.3.1",
     "uuid": "^8.3.2"
@@ -121,6 +121,7 @@
     "lint-staged": "^11.1.2",
     "react-dnd-html5-backend": "^11.1.3",
     "redux-mock-store": "^1.5.4",
+    "rendition": "^21.7.16",
     "simple-git-hooks": "^2.6.1",
     "sinon": "^11.1.2",
     "ts-jest": "^26.5.6",


### PR DESCRIPTION
This reduces the risk of obscure bgs happening due to msmatched
rendition versions, especially in theme providers.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>