### PR TITLE
Fix Illegal Invocation error

### DIFF
--- a/lib/Timeline/MessageInput.tsx
+++ b/lib/Timeline/MessageInput.tsx
@@ -184,7 +184,6 @@ const MessageInput: React.FunctionComponent<MessageInputProps> = ({
 
 	const onInputChange = React.useCallback(
 		(event) => {
-			event.preventDefault();
 			const messageText = event.target.value;
 			setMessage(messageText);
 			if (onChange) {


### PR DESCRIPTION
Change-type: patch

***

This [commit](https://github.com/webscopeio/react-textarea-autocomplete/commit/7a302efb973b48a765f4bd47cea0187fe63fa88f) caused `event.preventDefault()` to throw, because event is a proxy.