### PR TITLE
Lock autocomplete textarea version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@sentry/browser": "^6.13.3",
-    "@webscopeio/react-textarea-autocomplete": "^4.8.0",
+    "@webscopeio/react-textarea-autocomplete": "4.7.3",
     "bluebird": "^3.7.2",
     "classnames": "^2.3.1",
     "color-hash": "^2.0.1",


### PR DESCRIPTION
Change-type: patch

***

Locking due to regression: https://github.com/webscopeio/react-textarea-autocomplete/issues/224