### PR TITLE
Update rendition from v21.x to v25.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@balena/jellyfish-client-sdk": "^7.0.36",
-    "rendition": "^21.12.7"
+    "rendition": "^25.4.9"
   },
   "dependencies": {
     "@sentry/browser": "^6.16.1",
@@ -117,7 +117,7 @@
     "lint-staged": "^11.2.6",
     "react-dnd-html5-backend": "^11.1.3",
     "redux-mock-store": "^1.5.4",
-    "rendition": "^21.12.7",
+    "rendition": "^25.4.10",
     "simple-git-hooks": "^2.7.0",
     "sinon": "^11.1.2",
     "ts-jest": "^26.5.6",

--- a/test/browser-setup.ts
+++ b/test/browser-setup.ts
@@ -1,2 +1,5 @@
 // tslint:disable-next-line:no-empty
 Element.prototype.scrollTo = () => {};
+
+// @ts-ignore
+global.fetch = jest.fn(() => Promise.resolve());

--- a/test/ui-setup.tsx
+++ b/test/ui-setup.tsx
@@ -41,12 +41,13 @@ class Location {}
 // @ts-ignore
 global.location = Location;
 
-// eslint-disable-next-line no-undef
+// @ts-ignore
+global.fetch = jest.fn(() => Promise.resolve());
+
 window.HTMLElement.prototype.scrollIntoView = _.noop;
 
 export const flushPromises = () => {
 	return new Promise((resolve) => {
-		// eslint-disable-next-line no-undef
 		return setImmediate(resolve);
 	});
 };


### PR DESCRIPTION
The breaking changes in rendition apply only to the `AutoUI` and
`DropDownButton` components, which aren't part of the components
exported by this module. However, because the peer dependency has now
increased, this new version will no longer be compatible with a number
of implementing projects, so this is a breaking change.

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>