### PR TITLE
Fix send command attribute

### DIFF
--- a/lib/Timeline/MessageInput.tsx
+++ b/lib/Timeline/MessageInput.tsx
@@ -211,6 +211,7 @@ const MessageInput: React.FunctionComponent<MessageInputProps> = ({
 
 	const textInput = (
 		<InputWrapper
+			data-test-send-command={sendCommand}
 			bubble={whisper}
 			py={2}
 			px={3}
@@ -310,12 +311,7 @@ const MessageInput: React.FunctionComponent<MessageInputProps> = ({
 						gridRow: 2,
 					}}
 				>
-					<Txt
-						fontSize={11}
-						italic
-						color="#859CB0"
-						data-test-send-command={sendCommand}
-					>
+					<Txt fontSize={11} italic color="#859CB0">
 						Press {sendCommand} to send
 					</Txt>
 				</Box>


### PR DESCRIPTION
Change-type: patch

---

Text with send command instructions is not visible on chat widget, so we need to put `data-test-send-command` attribute on the message input itself to make tests work.