### PR TITLE
analytics: Don't post a warning message when in a test environment

### DIFF
--- a/lib/services/analytics.ts
+++ b/lib/services/analytics.ts
@@ -12,7 +12,10 @@ export default class Analytics {
 		if (token) {
 			mixpanel.init(token, omit(config, 'token'));
 		} else {
-			console.warn('No token provided, skipping analytics setup');
+			// Don't post a warning if this code is running in a test environment.
+			if (!(process && process.env.NODE_ENV === 'test')) {
+				console.warn('No token provided, skipping analytics setup');
+			}
 			this.skip = true;
 		}
 		this.isInitialized = true;


### PR DESCRIPTION
This change should reduce the amount of noise when testing UI
components.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>